### PR TITLE
hostPkgs as argument.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 {
+  hostPkgs ? import <nixpkgs> {},
   pkgs ? (let
-      hostPkgs = import <nixpkgs> {};
       pinnedVersion = hostPkgs.lib.importJSON ./nixpkgs-18.03.json;
       pinnedPkgs = hostPkgs.fetchFromGitHub {
         owner = "NixOS";

--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@
     in import pinnedPkgs {}),
     #pkgs-unstable ? import (
     #pkfetchTarball "https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz") {},
-  mylib ? import ./mylib {}
+  mylib ? import ./mylib { inherit pkgs; }
 }:
 let
   # Add libraries to the scope of callPackage


### PR DESCRIPTION
hostPkgs should be an argument,  \<nixpkgs\> is system-dependent and that adds a dependency that is hard to track.