### PR TITLE
intervalset: 1.0.0 -> 1.1.0

### DIFF
--- a/intervalset/default.nix
+++ b/intervalset/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchgit, meson, ninja, pkgconfig, boost, gtest }:
 
 stdenv.mkDerivation rec {
-  version = "1.1.0-dev";
+  version = "1.1.0";
   name = "intervalset-${version}";
 
   src = fetchgit {
     url = "https://framagit.org/batsim/intervalset.git";
-    rev = "65a0626ad3b3a76e895540b3186dfa538fb55da5";
-    sha256 = "0i152xdgvqpc64p5lkfk7rzh6b2i59dy2s98ccs9pp22919k2yff";
+    rev = "v${version}";
+    sha256 = "0kksrr1l9gv7fg6rdjz39ph9l6smy74jsahyaj6pmpi1kzs33qva";
   };
 
-  nativeBuildInputs = [ meson ninja gtest pkgconfig ];
+  nativeBuildInputs = [ meson ninja pkgconfig ];
   buildInputs = [ boost gtest ];
 
   meta = with stdenv.lib; {

--- a/intervalset/default.nix
+++ b/intervalset/default.nix
@@ -1,25 +1,17 @@
-{ stdenv, fetchgit, cmake, boost, gtest }:
+{ stdenv, fetchgit, meson, ninja, pkgconfig, boost, gtest }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.0";
+  version = "1.1.0-dev";
   name = "intervalset-${version}";
 
   src = fetchgit {
     url = "https://framagit.org/batsim/intervalset.git";
-    rev = "v${version}";
-    sha256 = "05nzqvmhi9dhqs0yzw7g6ybkdxkp74hnc53w4w4aa22a65dji637";
+    rev = "65a0626ad3b3a76e895540b3186dfa538fb55da5";
+    sha256 = "0i152xdgvqpc64p5lkfk7rzh6b2i59dy2s98ccs9pp22919k2yff";
   };
 
-  preConfigure = ''
-    # Always build on a clean directory
-    rm -rf ./build/*
-
-    # Enable linking to libintervalset.so (done by tests)
-    export LD_LIBRARY_PATH="$PWD/build"
-  '';
-
-  nativeBuildInputs = [ cmake gtest ];
-  buildInputs = [ boost ];
+  nativeBuildInputs = [ meson ninja gtest pkgconfig ];
+  buildInputs = [ boost gtest ];
 
   meta = with stdenv.lib; {
     description = "C++ library to manage sets of integral closed intervals";


### PR DESCRIPTION
- Use Meson instead of CMake
- Use new release (1.1.0)

Please notice gtest will not be found by Meson with the current release version of nixpkgs, as the gtest package has been fixed in [nixpkgs's 9ac64e5bb6](https://github.com/NixOS/nixpkgs/commit/9ac64e5bb65aeca34bef01e48fefaea186428bc1#diff-196fe90b285df238b11b3d9faf18645f). Lack of gtest does not make intervalset invalid, it just makes it untestable.